### PR TITLE
Add new index.php to fix mixed content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,22 @@ RUN composer --version
 RUN cd /var/www/ && rm html/* && composer create-project getkirby/starterkit html
 RUN mkdir -p /var/www/html/media && touch /var/www/html/media/index.html
 
+# enable support for HTTPS behind a proxy
+COPY <<-newindexphp index.php
+<?php
+
+if (isset(\$_SERVER['HTTP_X_FORWARDED_FOR'])) {
+    if (strpos(\$_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {
+            \$_SERVER['HTTPS'] = true;
+    }
+}
+
+require 'kirby/bootstrap.php';
+
+echo (new Kirby)->render();
+
+newindexphp
+
 # install some kirby plugins
 RUN composer require getkirby/cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cd /var/www/ && rm html/* && composer create-project getkirby/starterkit htm
 RUN mkdir -p /var/www/html/media && touch /var/www/html/media/index.html
 
 # enable support for HTTPS behind a proxy
-COPY <<-newindexphp index.php
+COPY <<-newindexphp /var/www/html/index.php
 <?php
 
 if (isset(\$_SERVER['HTTP_X_FORWARDED_FOR'])) {


### PR DESCRIPTION
When running behind Proxy the HTML Pages are delivered with HTTPS but not the JS or CSS files.
